### PR TITLE
Adds a link to a figma design file for the protocl

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ GEB is a modified fork of [MCD](https://github.com/makerdao/dss) that has severa
 
 ### GEB Overview Diagram
 
-Explore the diagram in detail [here](https://viewer.diagrams.net/?target=blank\&highlight=0000ff\&layers=1\&nav=1\&title=GEB\_overview.drawio#Uhttps%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1nIcaY8N8StVCfyAL\_ztbmETJX2bvY3a9%26export%3Ddownload).
+Explore the diagram in detail [here](https://viewer.diagrams.net/?target=blank\&highlight=0000ff\&layers=1\&nav=1\&title=GEB\_overview.drawio#Uhttps%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1nIcaY8N8StVCfyAL\_ztbmETJX2bvY3a9%26export%3Ddownload) or try [this forkable figma file](https://www.figma.com/file/5GL7lVwqNeNKIcANCgCJjl/GEB-Diagram-Share?type=whiteboard&node-id=2%3A2309&t=0rX2ms301RyaibG8-1).
 
 ![](.gitbook/assets/geb\_overview-1-.png)
 


### PR DESCRIPTION
The figma is exactly the same as the other GEB diagram but is much easier to read and see whats happening IMO. It's also color coded + has some more info. While working on a RAI fork, we have found it very helpful to use this, easily clone the figma and make changes to design changes to GEB, and we want to share this resource with the community. 

https://www.figma.com/file/5GL7lVwqNeNKIcANCgCJjl/GEB-Diagram-Share?type=whiteboard&node-id=2%3A2309&t=0rX2ms301RyaibG8-1

It would be cool to embed it like this but I understand if that's too much of a change / using the official static diagram is preferable. 

```
<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F5GL7lVwqNeNKIcANCgCJjl%2FGEB-Diagram-Share%3Ftype%3Dwhiteboard%26node-id%3D0%253A1%26t%3D0rX2ms301RyaibG8-1" allowfullscreen></iframe>
```

h/t to the fantastic @daopunk for making this great asset!